### PR TITLE
全関節のリンクの情報を追加

### DIFF
--- a/Kinematics/Kinematics.cpp
+++ b/Kinematics/Kinematics.cpp
@@ -95,7 +95,7 @@ bool Kinematics::calcInverseKinematics(int to, Link target)
 		err = calcVWerr(target, ulink[to]);
 		if(err.norm() < eps) return true;
 		
-		if(idx == 6)
+		if(idx.size() == 6)
 			dq = lambda * (J.inverse() * err);
 		else
 			dq = lambda * ((J.transpose()*J).inverse()*J.transpose()*err);

--- a/Kinematics/Link.cpp
+++ b/Kinematics/Link.cpp
@@ -4,7 +4,7 @@ using namespace MotionControl;
 
 extern "C" void SetJointInfo(struct Link *link)
 {
-	for(int i=0;i<ARM_JOINT_NUM;i++)
+	for(int i=0;i<LEG_JOINT_NUM;i++)
 	{
 		link[i].joint_name = joint_name[i];
 		link[i].parent = parent[i];

--- a/Kinematics/Link.cpp
+++ b/Kinematics/Link.cpp
@@ -4,7 +4,7 @@ using namespace MotionControl;
 
 extern "C" void SetJointInfo(struct Link *link)
 {
-	for(int i=0;i<LEG_JOINT_NUM;i++)
+	for(int i=0;i<ARM_JOINT_NUM;i++)
 	{
 		link[i].joint_name = joint_name[i];
 		link[i].parent = parent[i];

--- a/Kinematics/Link.cpp
+++ b/Kinematics/Link.cpp
@@ -4,7 +4,7 @@ using namespace MotionControl;
 
 extern "C" void SetJointInfo(struct Link *link)
 {
-	for(int i=0;i<LEG_JOINT_NUM;i++)
+	for(int i=0;i<JOINT_NUM;i++)
 	{
 		link[i].joint_name = joint_name[i];
 		link[i].parent = parent[i];

--- a/Kinematics/LinkParameter.h
+++ b/Kinematics/LinkParameter.h
@@ -35,6 +35,27 @@ static const string joint_name[] = {
 	"LLEG_JOINT3",
 	"LLEG_JOINT4",
 	"LLEG_JOINT5",
+	"CHEST_JOINT0",
+	"CHEST_JOINT1",
+	"CHEST_JOINT2",
+	"HEAD_JOINT0",
+	"HEAD_JOINT1",
+	"RARM_JOINT0",
+	"RARM_JOINT1",
+	"RARM_JOINT2",
+	"RARM_JOINT3",
+	"RARM_JOINT4",
+	"RARM_JOINT5",
+	"RARM_JOINT6",
+	"RARM_JOINT7",
+	"LARM_JOINT0",
+	"LARM_JOINT1",
+	"LARM_JOINT2",
+	"LARM_JOINT3",
+	"LARM_JOINT4",
+	"LARM_JOINT5",
+	"LARM_JOINT6",
+	"LARM_JOINT7",
 };
 
 enum
@@ -52,16 +73,39 @@ enum
 	LLEG_JOINT3,
 	LLEG_JOINT4,
 	LLEG_JOINT5,
-	LEG_JOINT_NUM
+	CHEST_JOINT0,
+	CHEST_JOINT1,
+	CHEST_JOINT2,
+	HEAD_JOINT0,
+	HEAD_JOINT1,
+	RARM_JOINT0,
+	RARM_JOINT1,
+	RARM_JOINT2,
+	RARM_JOINT3,
+	RARM_JOINT4,
+	RARM_JOINT5,
+	RARM_JOINT6,
+	RARM_JOINT7,
+	LARM_JOINT0,
+	LARM_JOINT1,
+	LARM_JOINT2,
+	LARM_JOINT3,
+	LARM_JOINT4,
+	LARM_JOINT5,
+	LARM_JOINT6,
+	LARM_JOINT7,
+	JOINT_NUM
 };
 
-static const int parent[LEG_JOINT_NUM] = {-1,0,1,2,3,4,5,0,7,8,9,10,11};
-static const int child[LEG_JOINT_NUM] = {1,2,3,4,5,6,-1,8,9,10,11,12,-1};
-static const int sister[LEG_JOINT_NUM] = {-1,7,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+static const int parent[JOINT_NUM] = {-1,0,1,2,3,4,5,0,7,8,9,10,11,0,13,14,15,16,15,18,19,20,21,22,23,24,15,26,27,28,29,30,31,32};
+static const int child[JOINT_NUM] = {1,2,3,4,5,6,-1,8,9,10,11,12,-1,14,15,16,17,-1,19,20,21,22,23,24,25,-1,27,28,29,30,31,32,33,-1};
+static const int sister[JOINT_NUM] = {-1,7,-1,-1,-1,-1,-1,13,-1,-1,-1,-1,-1,18,-1,-1,-1,-1,26,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
 
-static const double LinkAxis[LEG_JOINT_NUM][3] = {
+static const double LinkAxis[JOINT_NUM][3] = {
+	//WASIT
 	{0,0,0},
 
+	//RLEG
 	{0,0,1},
 	{1,0,0},
 	{0,1,0},
@@ -69,104 +113,92 @@ static const double LinkAxis[LEG_JOINT_NUM][3] = {
 	{0,1,0},
 	{1,0,0},
 
+	//LLEG
 	{0,0,1},
 	{1,0,0},
 	{0,1,0},
 	{0,1,0},
 	{0,1,0},
 	{1,0,0},
+
+	//CHEST
+	{1,0,0},
+	{0,1,0},
+	{0,0,1},
+
+	//HEAD
+	{0,0,1},
+	{0,1,0},
+
+	//RARM
+	{0,0,1},
+	{0,1,0},
+	{1,0,0},
+	{0,0,1},
+	{0,1,0},
+	{0,0,1},
+	{1,0,0},
+	{0,1,0},
+
+	//LARM
+	{0,0,1},
+	{0,1,0},
+	{1,0,0},
+	{0,0,1},
+	{0,1,0},
+	{0,0,1},
+	{1,0,0},
+	{0,1,0},
 };
 
-static const double LinkPos[LEG_JOINT_NUM][3] = {
+static const double LinkPos[JOINT_NUM][3] = {
+	//WAIST
 	{0.0f, 0.0f, 1022.5f},	
-		
+	
+	//RLEG	
 	{0.0f, -100.0f, 1032.0f},
-	{0.0f, -0.0f, -122.0f},
-	{0.0f, -0.0f, -10.0f},
-	{0.0f, 0.0f, -380.0f},
-	{0.0f, 0.0f, -380.0f},
-	{0.0f, 0.0f, -40.0f},
-
-	{6.0f, 100.0f, 1032.0f},
 	{0.0f, 0.0f, -122.0f},
 	{0.0f, 0.0f, -10.0f},
 	{0.0f, 0.0f, -380.0f},
 	{0.0f, 0.0f, -380.0f},
 	{0.0f, 0.0f, -40.0f},
-};
 
-/*
-//Accelite(RoboCup Humanoid)
-static const string joint_name[] = {
-	"WAIST",
-	"HIP_YAW_L",
-	"HIP_ROLL_L",
-	"HIP_PITCH_L",
-	"KNEE_PITCH_L",
-	"FOOT_PTICH_L",
-	"FOOT_ROLL_L",
-	"HIP_YAW_R",
-	"HIP_ROLL_R",
-	"HIP_PITCH_R",
-	"KNEE_PITCH_R",
-	"FOOT_PITCH_R",
-	"FOOT_ROLL_R",	
-};
+	//LLEG
+	{0.0f, 100.0f, 1032.0f},
+	{0.0f, 0.0f, -122.0f},
+	{0.0f, 0.0f, -10.0f},
+	{0.0f, 0.0f, -380.0f},
+	{0.0f, 0.0f, -380.0f},
+	{0.0f, 0.0f, -40.0f},
 
-enum
-{
-	WAIST=0,
-	HIP_YAW_L,
-	HIP_ROLL_L,
-	HIP_PITCH_L,
-	KNEE_PITCH_L,
-	FOOT_PITCH_L,
-	FOOT_ROLL_L,
-	HIP_YAW_R,
-	HIP_ROLL_R,
-	HIP_PITCH_R,
-	KNEE_PITCH_R,
-	FOOT_PITCH_R,
-	FOOT_ROLL_R,
-	LEG_JOINT_NUM
-};
+	//CHEST
+	{6.0f, 0.0f, 1150.5f},
+	{0.0f, 0.0f, 25.0f},
+	{0.0f, 0.0f, -308.5f},
 
-static const int parent[LEG_JOINT_NUM] = {-1,0,1,2,3,4,5,0,7,8,9,10,11};
-static const int child[LEG_JOINT_NUM] = {1,2,3,4,5,6,-1,8,9,10,11,12,-1};
-static const int sister[LEG_JOINT_NUM] = {-1,-1,7,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+	//HEAD
+	{-15.0f, 0.0f, -83.5f},
+	{0.0f, 0.0f, -102.0f},
 
-static const double LinkAxis[LEG_JOINT_NUM][3] = {
-	{0,0,0},	//WASIT
-	{0,0,1},
-	{1,0,0},
-	{0,1,0},
-	{0,1,0},
-	{0,1,0},
-	{1,0,0},
-	{0,0,1},
-	{1,0,0},
-	{0,1,0},
-	{0,1,0},
-	{0,1,0},
-	{1,0,0},
-};
+	//RARM
+	{6.0f, -87.5f, 1484.0f},
+	{0.0f, -72.8f, 0.0f},
+	{0.0f, -56.9f, 0.0f},
+	{0.0f, 0.0f, -196.5f},
+	{0.0f, 0.0f, -126.0f},
+	{0.0f, 0.0f, -127.5f},
+	{0.0f, 0.0f, -146.0f},
+	{0.0f, 0.0f, -40.0f},
 
-//For test
-static const double LinkPos[LEG_JOINT_NUM][3] = {
-	{0.0f, 0.0f, 0.0f},		//WAIST
-	{0.0f, -50.0f, 0.0f},	//HIP_YAW_L
-	{0.0f, 0.0f, -0.0f},	//HIP_ROLL_L
-	{0.0f, 0.0f, 0.0f},		//HIP_PITCH_L
-	{0.0f, 0.0f, -100.0f},	//KNEE_PITCH_L
-	{0.0f, 0.0f, -100.0f},	//FOOT_PITCH_L
-	{0.0f, 0.0f, 0.0f},		//FOOT_ROLL_L
-	{0.0f, 50.0f, 0.0f},	//HIP_YAW_R
-	{0.0f, 0.0f, -0.0f},	//HIP_ROLL_R
-	{0.0f, 0.0f, 0.0f},		//HIP_PITCH_R
-	{0.0f, 0.0f, -100.0f},	//KNEE_PITCH_R
-	{0.0f, 0.0f, -100.0f},	//FOOT_PITCH_R
-	{0.0f, 0.0f, 0.0f},		//FOOT_ROLL_R
+	//LARM
+	{6.0f, 87.5f, 1484.0f},
+	{0.0f, 72.8f, 0.0f},
+	{0.0f, 56.9f, 0.0f},
+	{0.0f, 0.0f, -196.5f},
+	{0.0f, 0.0f, -126.0f},
+	{0.0f, 0.0f, -127.5f},
+	{0.0f, 0.0f, -146.0f},
+	{0.0f, 0.0f, -40.0f},
 };
-*/
 
 #endif

--- a/Kinematics/LinkParameter.h
+++ b/Kinematics/LinkParameter.h
@@ -63,12 +63,13 @@ enum
 	ARM_JOINT_NUM
 };
 
-static const int parent[LEG_JOINT_NUM] = {-1,0,1,2,3,4,5,6,7,0,9,10,11,12,13,14,15};
-static const int child[LEG_JOINT_NUM] = {1,2,3,4,5,6,7,8,-1,10,11,12,13,14,15,16,-1};
-static const int sister[LEG_JOINT_NUM] = {-1,9,-1,-1,-1,-1,-1,-1,-1,1,-1,-1,-1,-1,-1,-1,-1};
+static const int parent[ARM_JOINT_NUM] = {-1,0,1,2,3,4,5,6,7,0,9,10,11,12,13,14,15};
+static const int child[ARM_JOINT_NUM] = {1,2,3,4,5,6,7,8,-1,10,11,12,13,14,15,16,-1};
+static const int sister[ARM_JOINT_NUM] = {-1,9,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
 
-static const double LinkAxis[LEG_JOINT_NUM][3] = {
+static const double LinkAxis[ARM_JOINT_NUM][3] = {
 	{0,0,0},
+
 	{0,0,1},
 	{0,1,0},
 	{1,0,0},
@@ -77,6 +78,7 @@ static const double LinkAxis[LEG_JOINT_NUM][3] = {
 	{0,0,1},
 	{1,0,0},
 	{0,1,0},
+
 	{0,0,1},
 	{0,1,0},
 	{1,0,0},
@@ -87,24 +89,24 @@ static const double LinkAxis[LEG_JOINT_NUM][3] = {
 	{0,1,0},
 };
 
-static const double LinkPos[LEG_JOINT_NUM][3] = {
+static const double LinkPos[ARM_JOINT_NUM][3] = {
 	{6.0f, 0.0f, 1484.0f},	
 		
-	{0.0f, -87.5f, 0.0f},
+	{6.0f, -87.5f, 1484.0f},
 	{0.0f, -72.8f, 0.0f},
 	{0.0f, -56.9f, 0.0f},
 	{0.0f, 0.0f, -196.5f},
 	{0.0f, 0.0f, -126.0f},
-	{0.0f, 0.0f, -253.5f},
+	{0.0f, 0.0f, -127.5f},
 	{0.0f, 0.0f, -146.0f},
 	{0.0f, 0.0f, -40.0f},
 
-	{0.0f, 87.5f, 0.0f},
+	{6.0f, 87.5f, 1484.0f},
 	{0.0f, 72.8f, 0.0f},
 	{0.0f, 56.9f, 0.0f},
 	{0.0f, 0.0f, -196.5f},
 	{0.0f, 0.0f, -126.0f},
-	{0.0f, 0.0f, -253.5},
+	{0.0f, 0.0f, -127.5},
 	{0.0f, 0.0f, -146.0f},
 	{0.0f, 0.0f ,-40.0f},
 };

--- a/Kinematics/LinkParameter.h
+++ b/Kinematics/LinkParameter.h
@@ -1,6 +1,6 @@
 /*
  * @file		LinkParameter.h
- * @brief		Constant Value of Link for Accelite
+ * @brief		Constant Value of Link for Humanoid Robot
  * @author	Ryu Yamamoto
  * @date		2016/02/26
  */
@@ -17,12 +17,100 @@
 using namespace std;
 using namespace Eigen;
 
-static const int ACCELITE_ELBOW = 19;
-static const int ACCELITE = 17;
-
 static const double eps = numeric_limits<double>::epsilon();
 static const double pi = boost::math::constants::pi<double>();
 
+//JAXON
+static const string joint_name[] = {
+	"WAIST",
+	"RARM_JOINT0",
+	"RARM_JOINT1",
+	"RARM_JOINT2",
+	"RARM_JOINT3",
+	"RARM_JOINT4",
+	"RARM_JOINT5",
+	"RARM_JOINT6",
+	"RARM_JOINT7",
+	"LARM_JOINT0",
+	"LARM_JOINT1",
+	"LARM_JOINT2",
+	"LARM_JOINT3",
+	"LARM_JOINT4",
+	"LARM_JOINT5",
+	"LARM_JOINT6",
+	"LARM_JOINT7",
+};
+
+enum
+{
+	WAIST=0,
+	RARM_JOINT0,
+	RARM_JOINT1,
+	RARM_JOINT2,
+	RARM_JOINT3,
+	RARM_JOINT4,
+	RARM_JOINT5,
+	RARM_JOINT6,
+	RARM_JOINT7,
+	LARM_JOINT0,
+	LARM_JOINT1,
+	LARM_JOINT2,
+	LARM_JOINT3,
+	LARM_JOINT4,
+	LARM_JOINT5,
+	LARM_JOINT6,
+	LARM_JOINT7,
+	ARM_JOINT_NUM
+};
+
+static const int parent[LEG_JOINT_NUM] = {-1,0,1,2,3,4,5,6,7,0,9,10,11,12,13,14,15};
+static const int child[LEG_JOINT_NUM] = {1,2,3,4,5,6,7,8,-1,10,11,12,13,14,15,16,-1};
+static const int sister[LEG_JOINT_NUM] = {-1,9,-1,-1,-1,-1,-1,-1,-1,1,-1,-1,-1,-1,-1,-1,-1};
+
+static const double LinkAxis[LEG_JOINT_NUM][3] = {
+	{0,0,0},
+	{0,0,1},
+	{0,1,0},
+	{1,0,0},
+	{0,0,1},
+	{0,1,0},
+	{0,0,1},
+	{1,0,0},
+	{0,1,0},
+	{0,0,1},
+	{0,1,0},
+	{1,0,0},
+	{0,0,1},
+	{0,1,0},
+	{0,0,1},
+	{1,0,0},
+	{0,1,0},
+};
+
+static const double LinkPos[LEG_JOINT_NUM][3] = {
+	{6.0f, 0.0f, 1484.0f},	
+		
+	{0.0f, -87.5f, 0.0f},
+	{0.0f, -72.8f, 0.0f},
+	{0.0f, -56.9f, 0.0f},
+	{0.0f, 0.0f, -196.5f},
+	{0.0f, 0.0f, -126.0f},
+	{0.0f, 0.0f, -253.5f},
+	{0.0f, 0.0f, -146.0f},
+	{0.0f, 0.0f, -40.0f},
+
+	{0.0f, 87.5f, 0.0f},
+	{0.0f, 72.8f, 0.0f},
+	{0.0f, 56.9f, 0.0f},
+	{0.0f, 0.0f, -196.5f},
+	{0.0f, 0.0f, -126.0f},
+	{0.0f, 0.0f, -253.5},
+	{0.0f, 0.0f, -146.0f},
+	{0.0f, 0.0f ,-40.0f},
+};
+
+/*
+//Accelite(RoboCup Humanoid)
 static const string joint_name[] = {
 	"WAIST",
 	"HIP_YAW_L",
@@ -57,12 +145,6 @@ enum
 	LEG_JOINT_NUM
 };
 
-enum LegType
-{
-	PARALLEL_LINK=0,
-	SERIAL_LINK
-};
-
 static const int parent[LEG_JOINT_NUM] = {-1,0,1,2,3,4,5,0,7,8,9,10,11};
 static const int child[LEG_JOINT_NUM] = {1,2,3,4,5,6,-1,8,9,10,11,12,-1};
 static const int sister[LEG_JOINT_NUM] = {-1,-1,7,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
@@ -83,25 +165,6 @@ static const double LinkAxis[LEG_JOINT_NUM][3] = {
 	{1,0,0},
 };
 
-//For Accelite
-/*
-static const double LinkPos[LEG_JOINT_NUM][3] = {
-	{0,0,0},			//WAIST
-	{0,44.0f,0},		//HIP_YAW_L
-	{0.0,0.0,-42.8f},	//HIP_ROLL_L
-	{15.0f,0.0,0.0},	//
-	{0.0,0.0,-105.0f},	
-	{0.0,0.0,-41.0f},
-	{0.0,0.0,-105.0f},
-	{0,-44.0f,0},
-	{},
-	{},
-	{},
-	{},
-	{}
-};
-*/
-
 //For test
 static const double LinkPos[LEG_JOINT_NUM][3] = {
 	{0.0f, 0.0f, 0.0f},		//WAIST
@@ -118,5 +181,6 @@ static const double LinkPos[LEG_JOINT_NUM][3] = {
 	{0.0f, 0.0f, -100.0f},	//FOOT_PITCH_R
 	{0.0f, 0.0f, 0.0f},		//FOOT_ROLL_R
 };
+*/
 
 #endif

--- a/Kinematics/LinkParameter.h
+++ b/Kinematics/LinkParameter.h
@@ -23,92 +23,76 @@ static const double pi = boost::math::constants::pi<double>();
 //JAXON
 static const string joint_name[] = {
 	"WAIST",
-	"RARM_JOINT0",
-	"RARM_JOINT1",
-	"RARM_JOINT2",
-	"RARM_JOINT3",
-	"RARM_JOINT4",
-	"RARM_JOINT5",
-	"RARM_JOINT6",
-	"RARM_JOINT7",
-	"LARM_JOINT0",
-	"LARM_JOINT1",
-	"LARM_JOINT2",
-	"LARM_JOINT3",
-	"LARM_JOINT4",
-	"LARM_JOINT5",
-	"LARM_JOINT6",
-	"LARM_JOINT7",
+	"RLEG_JOINT0",
+	"RLEG_JOINT1",
+	"RLEG_JOINT2",
+	"RLEG_JOINT3",
+	"RLEG_JOINT4",
+	"RLEG_JOINT5",
+	"LLEG_JOINT0",
+	"LLEG_JOINT1",
+	"LLEG_JOINT2",
+	"LLEG_JOINT3",
+	"LLEG_JOINT4",
+	"LLEG_JOINT5",
 };
 
 enum
 {
 	WAIST=0,
-	RARM_JOINT0,
-	RARM_JOINT1,
-	RARM_JOINT2,
-	RARM_JOINT3,
-	RARM_JOINT4,
-	RARM_JOINT5,
-	RARM_JOINT6,
-	RARM_JOINT7,
-	LARM_JOINT0,
-	LARM_JOINT1,
-	LARM_JOINT2,
-	LARM_JOINT3,
-	LARM_JOINT4,
-	LARM_JOINT5,
-	LARM_JOINT6,
-	LARM_JOINT7,
-	ARM_JOINT_NUM
+	RLEG_JOINT0,
+	RLEG_JOINT1,
+	RLEG_JOINT2,
+	RLEG_JOINT3,
+	RLEG_JOINT4,
+	RLEG_JOINT5,
+	LLEG_JOINT0,
+	LLEG_JOINT1,
+	LLEG_JOINT2,
+	LLEG_JOINT3,
+	LLEG_JOINT4,
+	LLEG_JOINT5,
+	LEG_JOINT_NUM
 };
 
-static const int parent[ARM_JOINT_NUM] = {-1,0,1,2,3,4,5,6,7,0,9,10,11,12,13,14,15};
-static const int child[ARM_JOINT_NUM] = {1,2,3,4,5,6,7,8,-1,10,11,12,13,14,15,16,-1};
-static const int sister[ARM_JOINT_NUM] = {-1,9,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+static const int parent[LEG_JOINT_NUM] = {-1,0,1,2,3,4,5,0,7,8,9,10,11};
+static const int child[LEG_JOINT_NUM] = {1,2,3,4,5,6,-1,8,9,10,11,12,-1};
+static const int sister[LEG_JOINT_NUM] = {-1,7,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
 
-static const double LinkAxis[ARM_JOINT_NUM][3] = {
+static const double LinkAxis[LEG_JOINT_NUM][3] = {
 	{0,0,0},
 
 	{0,0,1},
-	{0,1,0},
-	{1,0,0},
-	{0,0,1},
-	{0,1,0},
-	{0,0,1},
 	{1,0,0},
 	{0,1,0},
+	{0,1,0},
+	{0,1,0},
+	{1,0,0},
 
 	{0,0,1},
-	{0,1,0},
-	{1,0,0},
-	{0,0,1},
-	{0,1,0},
-	{0,0,1},
 	{1,0,0},
 	{0,1,0},
+	{0,1,0},
+	{0,1,0},
+	{1,0,0},
 };
 
-static const double LinkPos[ARM_JOINT_NUM][3] = {
-	{6.0f, 0.0f, 1484.0f},	
+static const double LinkPos[LEG_JOINT_NUM][3] = {
+	{0.0f, 0.0f, 1022.5f},	
 		
-	{6.0f, -87.5f, 1484.0f},
-	{0.0f, -72.8f, 0.0f},
-	{0.0f, -56.9f, 0.0f},
-	{0.0f, 0.0f, -196.5f},
-	{0.0f, 0.0f, -126.0f},
-	{0.0f, 0.0f, -127.5f},
-	{0.0f, 0.0f, -146.0f},
+	{0.0f, -100.0f, 1032.0f},
+	{0.0f, -0.0f, -122.0f},
+	{0.0f, -0.0f, -10.0f},
+	{0.0f, 0.0f, -380.0f},
+	{0.0f, 0.0f, -380.0f},
 	{0.0f, 0.0f, -40.0f},
 
-	{6.0f, 87.5f, 1484.0f},
-	{0.0f, 72.8f, 0.0f},
-	{0.0f, 56.9f, 0.0f},
-	{0.0f, 0.0f, -196.5f},
-	{0.0f, 0.0f, -126.0f},
-	{0.0f, 0.0f, -127.5},
-	{0.0f, 0.0f, -146.0f},
-	{0.0f, 0.0f ,-40.0f},
+	{6.0f, 100.0f, 1032.0f},
+	{0.0f, 0.0f, -122.0f},
+	{0.0f, 0.0f, -10.0f},
+	{0.0f, 0.0f, -380.0f},
+	{0.0f, 0.0f, -380.0f},
+	{0.0f, 0.0f, -40.0f},
 };
 
 /*

--- a/Kinematics/testKinematics.cpp
+++ b/Kinematics/testKinematics.cpp
@@ -18,29 +18,16 @@ double deg2rad(double degree)
 int main(int argc, char* argv[])
 {
 	//Initialize
-	Link ulink[ARM_JOINT_NUM];
+	Link ulink[LEG_JOINT_NUM];
 	SetJointInfo(ulink);
 	Kinematics kine(ulink);
 
 	//Set Angle to Joint
-	for(int i=0;i<ARM_JOINT_NUM;i++)
+	for(int i=0;i<LEG_JOINT_NUM;i++)
 		kine.ulink[i].q = 0.0f;
-	/*kine.ulink[RARM_JOINT1].q = deg2rad(40.0);
-	kine.ulink[RARM_JOINT2].q = deg2rad(-15.0);*/
-	kine.ulink[RARM_JOINT4].q = deg2rad(-80.0);
-	kine.ulink[RARM_JOINT6].q = deg2rad(-80.0);
-	/*kine.ulink[RARM_JOINT7].q = deg2rad(-40.0);
-	kine.ulink[LARM_JOINT1].q = deg2rad(40.0);
-	kine.ulink[LARM_JOINT2].q = deg2rad(15.0);
-	kine.ulink[LARM_JOINT3].q = deg2rad(-90.0);
-	kine.ulink[LARM_JOINT4].q = deg2rad(15.0);
-	kine.ulink[LARM_JOINT7].q = deg2rad(-40.0);*/
 	
 	//Calculation Forward Kinematics
 	kine.calcForwardKinematics(WAIST);	
-	for(int i=0;i<ARM_JOINT_NUM;i++)
-		cout<<kine.ulink[i].joint_name<<": "<<rad2deg(kine.ulink[i].q)<<endl;
-	cout<<"larm:"<<kine.ulink[LARM_JOINT7].p<<endl;
-	cout<<"rarm:"<<kine.ulink[RARM_JOINT7].p<<endl;
+	cout<<"rarm:"<<kine.ulink[RLEG_JOINT5].p<<endl;	
 	return 0;
 }

--- a/Kinematics/testKinematics.cpp
+++ b/Kinematics/testKinematics.cpp
@@ -18,16 +18,37 @@ double deg2rad(double degree)
 int main(int argc, char* argv[])
 {
 	//Initialize
-	Link ulink[LEG_JOINT_NUM];
+	Link ulink[JOINT_NUM];
 	SetJointInfo(ulink);
 	Kinematics kine(ulink);
 
 	//Set Angle to Joint
-	for(int i=0;i<LEG_JOINT_NUM;i++)
+	for(int i=0;i<JOINT_NUM;i++)
 		kine.ulink[i].q = 0.0f;
-	
+	kine.ulink[RLEG_JOINT2].q = deg2rad(-15.0f);	
+	kine.ulink[RLEG_JOINT3].q = deg2rad(40.0f);
+	kine.ulink[RLEG_JOINT4].q = deg2rad(-25.0f);
+	kine.ulink[LLEG_JOINT2].q = deg2rad(-15.0f);
+	kine.ulink[LLEG_JOINT3].q = deg2rad(40.0f);
+	kine.ulink[LLEG_JOINT4].q = deg2rad(-25.0f);
+	kine.ulink[RARM_JOINT1].q = deg2rad(45.0f);
+	kine.ulink[RARM_JOINT2].q = deg2rad(-15.0f);
+	kine.ulink[RARM_JOINT4].q = deg2rad(-90.0f);
+	kine.ulink[RARM_JOINT5].q = deg2rad(-15.0f);
+	kine.ulink[RARM_JOINT7].q = deg2rad(-45.0f);
+	kine.ulink[LARM_JOINT1].q = deg2rad(45.0f);
+	kine.ulink[LARM_JOINT2].q = deg2rad(15.0f);
+	kine.ulink[LARM_JOINT4].q = deg2rad(-90.0f);
+	kine.ulink[LARM_JOINT5].q = deg2rad(15.0f);
+	kine.ulink[LARM_JOINT7].q = deg2rad(-45.0f);
+
 	//Calculation Forward Kinematics
-	kine.calcForwardKinematics(WAIST);	
-	cout<<"rarm:"<<kine.ulink[RLEG_JOINT5].p<<endl;	
+	kine.calcForwardKinematics(WAIST);
+	
+	cout<<"Right Foot Link pos:"<<endl;
+	cout<<kine.ulink[RLEG_JOINT5].p<<endl;
+	cout<<"Right Arm Link pos:"<<endl;
+	cout<<kine.ulink[RARM_JOINT7].p<<endl;
+	
 	return 0;
 }

--- a/Kinematics/testKinematics.cpp
+++ b/Kinematics/testKinematics.cpp
@@ -3,41 +3,44 @@
 using namespace std;
 using namespace MotionControl;
 
+double rad2deg(double radian)
+{
+	double degree = radian * 180.0f / pi;
+	return degree;
+}
+
+double deg2rad(double degree)
+{
+	double radian = degree * pi / 180.0f;
+	return radian;
+}
+
 int main(int argc, char* argv[])
 {
 	//Initialize
-	Link ulink[LEG_JOINT_NUM];
+	Link ulink[ARM_JOINT_NUM];
 	SetJointInfo(ulink);
 	Kinematics kine(ulink);
 
 	//Set Angle to Joint
-	for(int i=0;i<LEG_JOINT_NUM;i++)
-		kien.ulink[i].q = 0.0f;
-	kine.ulink[HIP_PITCH_L].q = -20 * pi / 180.0f;
-	kine.ulink[KNEE_PITCH_L].q = 40 * pi / 180.0f;
-	kine.ulink[FOOT_PITCH_L].q = -20 * pi / 180.0f;
-
-	//Calculation Forward Kinematics
-	kine.calcForwardKinematics(WAIST);
-
-	//Set Target Position of End Link
-	Link target_Lfoot;
-	const float move_eef=40.0;
-	target_Lfoot.p(0) = kine.ulink[FOOT_ROLL_L].p(0);
-	target_Lfoot.p(1)= kine.ulink[FOOT_ROLL_L].p(1);
-	target_Lfoot.p(2) = kine.ulink[FOOT_ROLL_L].p(2)+move_eef;
-
-	//Display Target Position
-	cout<<"Target Pos"<<endl;
-	cout<<target_Lfoot.p<<endl;
-	cout<<target_Lfoot.R<<endl;
-	cout<<"\n";
-
-	//Calculation Inverse Kinematics
-	kine.calcInverseKinematics(FOOT_ROLL_L,target_Lfoot);
-	cout<<"calc InverseKinematics..."<<endl;
-	cout<<ulink[HIP_PITCH_L].q*180.0f/pi<<endl;
-	cout<<ulink[KNEE_PITCH_L].q*180.0f/pi<<endl;
+	for(int i=0;i<ARM_JOINT_NUM;i++)
+		kine.ulink[i].q = 0.0f;
+	/*kine.ulink[RARM_JOINT1].q = deg2rad(40.0);
+	kine.ulink[RARM_JOINT2].q = deg2rad(-15.0);*/
+	kine.ulink[RARM_JOINT4].q = deg2rad(-80.0);
+	kine.ulink[RARM_JOINT6].q = deg2rad(-80.0);
+	/*kine.ulink[RARM_JOINT7].q = deg2rad(-40.0);
+	kine.ulink[LARM_JOINT1].q = deg2rad(40.0);
+	kine.ulink[LARM_JOINT2].q = deg2rad(15.0);
+	kine.ulink[LARM_JOINT3].q = deg2rad(-90.0);
+	kine.ulink[LARM_JOINT4].q = deg2rad(15.0);
+	kine.ulink[LARM_JOINT7].q = deg2rad(-40.0);*/
 	
+	//Calculation Forward Kinematics
+	kine.calcForwardKinematics(WAIST);	
+	for(int i=0;i<ARM_JOINT_NUM;i++)
+		cout<<kine.ulink[i].joint_name<<": "<<rad2deg(kine.ulink[i].q)<<endl;
+	cout<<"larm:"<<kine.ulink[LARM_JOINT7].p<<endl;
+	cout<<"rarm:"<<kine.ulink[RARM_JOINT7].p<<endl;
 	return 0;
 }


### PR DESCRIPTION
両脚、両腕、頭、腰のリンクの情報を追加。

順運動学の計算が全関節に対してできることを確認。逆運動学に関しては両脚は計算可、腕は8自由度な為まだ計算はできない。