### PR TITLE
3次元線形倒立振子による歩行パターン生成サンプルプログラムの追加

### DIFF
--- a/src/GaitGenerator/LIP/CMakeLists.txt
+++ b/src/GaitGenerator/LIP/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(LIP)
+
+set(CMAKE_CXX_FLAGS_RELEASE)
+find_package(Eigen3 REQUIRED)
+
+include_directories(
+	${EIGEN3_INCLUDE_DIR}
+)
+
+add_executable(LIP main.cpp LinearInvertedPendlum.cpp LinearInvertedPendlum.h)

--- a/src/GaitGenerator/LIP/LinearInvertedPendlum.cpp
+++ b/src/GaitGenerator/LIP/LinearInvertedPendlum.cpp
@@ -5,10 +5,12 @@ using namespace cit;
 void LinearInvertedPendlum::SetFootStep()
 {
 	this->foot_step_list.push_back(Vector3f(0.0, 0.2, 0.0));
-	this->foot_step_list.push_back(Vector3f(0.3, 0.2, 0.0));
-	this->foot_step_list.push_back(Vector3f(0.3, 0.2, 0.0));
-	this->foot_step_list.push_back(Vector3f(0.3, 0.2, 0.0));
+	this->foot_step_list.push_back(Vector3f(0.3, 0.3, 0.0));
+	this->foot_step_list.push_back(Vector3f(0.3, 0.1, 0.0));
+	this->foot_step_list.push_back(Vector3f(0.3, 0.3, 0.0));
 	this->foot_step_list.push_back(Vector3f(0.0, 0.2, 0.0));
+	this->foot_step_list.push_back(Vector3f(0.0, 0.0, 0.0));
+	this->foot_step_list.push_back(Vector3f(0.0, 0.0, 0.0));
 }
 
 //STEP 3 & 4
@@ -20,15 +22,13 @@ void LinearInvertedPendlum::Integrate(int count)
 	this->count = count;
 	
 	//STEP3
-	for(float t=0.0;t<t_sup;t+=dt)
+	for(float t=0.0;t<=t_sup;t+=dt)
 	{
-		Vector2f temp_cog(0.0, 0.0);
 		x = (xi-pxa)*cosh(t/Tc) + Tc*dxi*sinh(t/Tc) + pxa;
 		y = (yi-pya)*cosh(t/Tc) + Tc*dyi*sinh(t/Tc) + pya;
 		dx = (xi-pxa)/Tc*sinh(t/Tc) + dxi*cosh(t/Tc);
 		dy = (yi-pya)/Tc*sinh(t/Tc) + dyi*cosh(t/Tc);
-		temp_cog << x, y;
-		cog_list.push_back(temp_cog);
+		cog_list.push_back(Vector2f(x, y));
 	}
 
 	//STEP4
@@ -40,20 +40,18 @@ void LinearInvertedPendlum::Integrate(int count)
 //STEP 5
 void LinearInvertedPendlum::CalcLegLandingPos()
 {
-	Vector2f temp_p(0.0, 0.0);
 	px = px + foot_step_list[count][0];
-	py = py - (pow(-1,count)*foot_step_list[count][1]);
-	temp_p << px, py;
-	p_list.push_back(temp_p);
+	py = py - (pow(-1,count+1)*foot_step_list[count][1]);
+	p_list.push_back(Vector2f(px, py));
 }
 
 //STEP 6
 void LinearInvertedPendlum::CalcWalkFragment()
 {
 	xb = foot_step_list[count+1][0]/2;
-	yb = pow(-1,count)*foot_step_list[count+1][1]/2;
-	vxb = (cosh(t_sup/Tc)+1)/(Tc*sinh(t_sup/Tc))*xb;
-	vyb = (cosh(t_sup/Tc)-1)/(Tc*sinh(t_sup/Tc))*yb;
+	yb = pow(-1,count+1)*foot_step_list[count+1][1]/2;
+	vxb = ((cosh(t_sup/Tc)+1)/(Tc*sinh(t_sup/Tc)))*xb;
+	vyb = ((cosh(t_sup/Tc)-1)/(Tc*sinh(t_sup/Tc)))*yb;
 }
 
 //STEP 7
@@ -68,10 +66,8 @@ void LinearInvertedPendlum::CalcGoalState()
 //STEP 8
 void LinearInvertedPendlum::ModifyLandPos()
 {
-	Vector2f temp_p_modi(0.0, 0.0);
-	pxa = -a*(cosh(t_sup/Tc)/D)*(xd-cosh(t_sup/Tc)*xi-Tc*sinh(t_sup/Tc)*dxi) - b*(sinh(t_sup/Tc)/(Tc*D))*(dxb-(sinh(t_sup/Tc)/Tc)*xi-cosh(t_sup/Tc)*dxi);
-	pya = -a*(cosh(t_sup/Tc)/D)*(yd-cosh(t_sup/Tc)*yi-Tc*sinh(t_sup/Tc)*dyi) - b*(sinh(t_sup/Tc)/(Tc*D))*(dyb-(sinh(t_sup/Tc)/Tc)*yi-cosh(t_sup/Tc)*dyi);
-	temp_p_modi << pxa, pya;
-	p_modi_list.push_back(temp_p_modi);
+	pxa = -a*(cosh(t_sup/Tc)-1)/D*(xd - cosh(t_sup/Tc)*xi - Tc*sinh(t_sup/Tc)*dxi) - b*sinh(t_sup/Tc)/(Tc*D)*(dxb - sinh(t_sup/Tc)/Tc*xi - cosh(t_sup/Tc)*dxi);
+	pya = -a*(cosh(t_sup/Tc)-1)/D*(yd - cosh(t_sup/Tc)*yi - Tc*sinh(t_sup/Tc)*dyi) - b*sinh(t_sup/Tc)/(Tc*D)*(dyb - sinh(t_sup/Tc)/Tc*yi - cosh(t_sup/Tc)*dyi);
+	p_modi_list.push_back(Vector2f(pxa, pya));
 }
 

--- a/src/GaitGenerator/LIP/LinearInvertedPendlum.cpp
+++ b/src/GaitGenerator/LIP/LinearInvertedPendlum.cpp
@@ -1,0 +1,77 @@
+#include "LinearInvertedPendlum.h"
+
+using namespace cit;
+
+void LinearInvertedPendlum::SetFootStep()
+{
+	this->foot_step_list.push_back(Vector3f(0.0, 0.2, 0.0));
+	this->foot_step_list.push_back(Vector3f(0.3, 0.2, 0.0));
+	this->foot_step_list.push_back(Vector3f(0.3, 0.2, 0.0));
+	this->foot_step_list.push_back(Vector3f(0.3, 0.2, 0.0));
+	this->foot_step_list.push_back(Vector3f(0.0, 0.2, 0.0));
+}
+
+//STEP 3 & 4
+void LinearInvertedPendlum::Integrate(int count)
+{
+	float x, y;
+	float dx, dy;
+
+	this->count = count;
+	
+	//STEP3
+	for(float t=0.0;t<t_sup;t+=dt)
+	{
+		Vector2f temp_cog(0.0, 0.0);
+		x = (xi-pxa)*cosh(t/Tc) + Tc*dxi*sinh(t/Tc) + pxa;
+		y = (yi-pya)*cosh(t/Tc) + Tc*dyi*sinh(t/Tc) + pya;
+		dx = (xi-pxa)/Tc*sinh(t/Tc) + dxi*cosh(t/Tc);
+		dy = (yi-pya)/Tc*sinh(t/Tc) + dyi*cosh(t/Tc);
+		temp_cog << x, y;
+		cog_list.push_back(temp_cog);
+	}
+
+	//STEP4
+	T =+ t_sup;
+	xi = x; yi = y;
+	dxi = dx; dyi = dy;
+}
+
+//STEP 5
+void LinearInvertedPendlum::CalcLegLandingPos()
+{
+	Vector2f temp_p(0.0, 0.0);
+	px = px + foot_step_list[count][0];
+	py = py - (pow(-1,count)*foot_step_list[count][1]);
+	temp_p << px, py;
+	p_list.push_back(temp_p);
+}
+
+//STEP 6
+void LinearInvertedPendlum::CalcWalkFragment()
+{
+	xb = foot_step_list[count+1][0]/2;
+	yb = pow(-1,count)*foot_step_list[count+1][1]/2;
+	vxb = (cosh(t_sup/Tc)+1)/(Tc*sinh(t_sup/Tc))*xb;
+	vyb = (cosh(t_sup/Tc)-1)/(Tc*sinh(t_sup/Tc))*yb;
+}
+
+//STEP 7
+void LinearInvertedPendlum::CalcGoalState()
+{
+	xd = px + xb;
+	dxb = vxb;
+	yd = py + yb;
+	dyb = vyb;
+}
+
+//STEP 8
+void LinearInvertedPendlum::ModifyLandPos()
+{
+	Vector2f temp_p_modi(0.0, 0.0);
+	pxa = -a*(cosh(t_sup/Tc)/D)*(xd-cosh(t_sup/Tc)*xi-Tc*sinh(t_sup/Tc)*dxi) - b*(sinh(t_sup/Tc)/(Tc*D))*(dxb-(sinh(t_sup/Tc)/Tc)*xi-cosh(t_sup/Tc)*dxi);
+	pya = -a*(cosh(t_sup/Tc)/D)*(yd-cosh(t_sup/Tc)*yi-Tc*sinh(t_sup/Tc)*dyi) - b*(sinh(t_sup/Tc)/(Tc*D))*(dyb-(sinh(t_sup/Tc)/Tc)*yi-cosh(t_sup/Tc)*dyi);
+	temp_p_modi << pxa, pya;
+	p_modi_list.push_back(temp_p_modi);
+}
+

--- a/src/GaitGenerator/LIP/LinearInvertedPendlum.h
+++ b/src/GaitGenerator/LIP/LinearInvertedPendlum.h
@@ -1,0 +1,68 @@
+#include <iostream>
+#include <vector>
+#include <math.h>
+#include <Eigen/Dense>
+#include <boost/math/constants/constants.hpp>
+
+using namespace std;
+using namespace Eigen;
+
+namespace cit
+{
+	static const float Zc = 0.8;
+	static const float ACCELALETION_GRAVITY = 9.81;
+	
+	class LinearInvertedPendlum
+	{
+		private:
+			float t_sup;
+			float dt;
+			float Tc;
+			float D;
+			int count;
+			const int a,b;
+			float x,y;
+			float xi,yi;
+			float xb,yb;
+			float xd,yd;
+			float dx,dy;
+			float dxi,dyi;
+			float dxb,dyb;
+			float vxb,vyb;
+			float px,py;
+			float pxa,pya;
+		public:
+			float T;
+			vector<Vector3f> foot_step_list;
+			vector<Vector2f> cog_list;
+			vector<Vector2f> p_list;
+			vector<Vector2f> p_modi_list;
+		public:
+			LinearInvertedPendlum(float _t_sup, float _dt, int _a, int _b)
+				: t_sup(_t_sup),
+				  dt(_dt),
+				  a(_a),
+				  b(_b)
+			{
+				Tc = sqrt(Zc/ACCELALETION_GRAVITY);
+				D = a*pow((cosh(t_sup/Tc)-1),2) + b*pow((sinh(t_sup/Tc)/Tc),2);
+				
+				count = 0;
+				T = 0;
+
+				//STEP 1
+				x = 0.0; y = 0.01;
+				dx = 0; dy = 0;
+				xi = x; yi = y;
+				dxi = dx, dyi = dy;
+				px = 0.0; py = 0.0;
+				pxa = px; pya = py;
+			}
+			void SetFootStep();
+			void Integrate(int count);
+			void CalcLegLandingPos();
+			void CalcWalkFragment();
+			void CalcGoalState();
+			void ModifyLandPos();
+	};
+}

--- a/src/GaitGenerator/LIP/LinearInvertedPendlum.h
+++ b/src/GaitGenerator/LIP/LinearInvertedPendlum.h
@@ -47,7 +47,6 @@ namespace cit
 				Tc = sqrt(Zc/ACCELALETION_GRAVITY);
 				D = a*pow((cosh(t_sup/Tc)-1),2) + b*pow((sinh(t_sup/Tc)/Tc),2);
 				
-				count = 0;
 				T = 0;
 
 				//STEP 1

--- a/src/GaitGenerator/LIP/main.cpp
+++ b/src/GaitGenerator/LIP/main.cpp
@@ -5,18 +5,21 @@ using namespace cit;
 int main(int argc, char* argv[])
 {
 	FILE *fp;
-	LinearInvertedPendlum LIP(0.8, 0.01, 10, 1);	//STEP 1
+	LinearInvertedPendlum LIP(0.8, 0.02, 10, 1);	//STEP 1
 	LIP.SetFootStep();	//STEP 2
 	LIP.p_list.push_back(Vector2f(0.0, 0.0));
 
 	/* Main Loop */
-	for(int n=0;n<=5;n++)
+	for(int n=0;n<6;n++)
 	{
 		LIP.Integrate(n);			//STEP 3 & 4
 		LIP.CalcLegLandingPos();	//STEP 5
 		LIP.CalcWalkFragment();		//STEP 6
 		LIP.CalcGoalState();		//STEP 7
 		LIP.ModifyLandPos();		//STEP 8
+		cout<<"px:"<<LIP.p_list[n][0]<<" py:"<<LIP.p_list[n][1]<<" pxa:"<<LIP.p_modi_list[n][0]<<" pya:"<<LIP.p_modi_list[n][1]<<endl;
+		//cout<<LIP.foot_step_list[n][0]<<" "<<LIP.foot_step_list[n][1]<<endl;
+		//printf("px:%f py:%f\n",LIP.p_list[count][0], LIP.p_list[count][1]);
 	}
 
 	/* Write Center of Mass to Csv File */

--- a/src/GaitGenerator/LIP/main.cpp
+++ b/src/GaitGenerator/LIP/main.cpp
@@ -1,0 +1,29 @@
+#include "LinearInvertedPendlum.h"
+
+using namespace cit;
+
+int main(int argc, char* argv[])
+{
+	FILE *fp;
+	LinearInvertedPendlum LIP(0.8, 0.01, 10, 1);	//STEP 1
+	LIP.SetFootStep();	//STEP 2
+	LIP.p_list.push_back(Vector2f(0.0, 0.0));
+
+	/* Main Loop */
+	for(int n=0;n<=5;n++)
+	{
+		LIP.Integrate(n);			//STEP 3 & 4
+		LIP.CalcLegLandingPos();	//STEP 5
+		LIP.CalcWalkFragment();		//STEP 6
+		LIP.CalcGoalState();		//STEP 7
+		LIP.ModifyLandPos();		//STEP 8
+	}
+
+	/* Write Center of Mass to Csv File */
+	fp = fopen("InvetedPendlumCOG.csv", "w");
+	for(size_t i=0;i<LIP.cog_list.size();i++)
+		fprintf(fp,"%lf %lf\n",LIP.cog_list[i][0],LIP.cog_list[i][1]);
+	fclose(fp);
+
+	return 0;
+}

--- a/src/GaitGenerator/LIP/main.cpp
+++ b/src/GaitGenerator/LIP/main.cpp
@@ -18,8 +18,6 @@ int main(int argc, char* argv[])
 		LIP.CalcGoalState();		//STEP 7
 		LIP.ModifyLandPos();		//STEP 8
 		cout<<"px:"<<LIP.p_list[n][0]<<" py:"<<LIP.p_list[n][1]<<" pxa:"<<LIP.p_modi_list[n][0]<<" pya:"<<LIP.p_modi_list[n][1]<<endl;
-		//cout<<LIP.foot_step_list[n][0]<<" "<<LIP.foot_step_list[n][1]<<endl;
-		//printf("px:%f py:%f\n",LIP.p_list[count][0], LIP.p_list[count][1]);
 	}
 
 	/* Write Center of Mass to Csv File */


### PR DESCRIPTION
5歩程度の歩行パターン生成のサンプルプログラムを追加。

旋回部分の計算に着いては勉強会で皆さんに追加していただきます。