### PR TITLE
fixed bug for CMakeLists.txt

### DIFF
--- a/choreonoid/rtc/PDController/CMakeLists.txt
+++ b/choreonoid/rtc/PDController/CMakeLists.txt
@@ -8,11 +8,29 @@ include(FindPkgConfig)
 pkg_check_modules(cnoid_plugin REQUIRED choreonoid-body-plugin)
 pkg_check_modules(openrtm_aist REQUIRED openrtm-aist)
 
-include_directories(${openrtm_aist_INCLUDE_DIRS} ${cnoid_plugin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
-link_directories(${openrtm_aist_LIBRARY_DIRS} ${cnoid_plugin_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS})
-add_library(PDController PDController.cpp)
-target_link_libraries(PDController  ${openrtm_aist_LIBRARIES} ${cnoid-plugin_LIBRARIES} ${Boost_LIBRARIES} hrpsysBaseStub CnoidOpenRTM)
-set_target_properties(PDController PROPERTIES COMPILE_FLAG "-fPIC" PREFIX "" SUFFIX ".so" LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
+include_directories(
+	${openrtm_aist_INCLUDE_DIRS}
+	${cnoid_plugin_INCLUDE_DIRS}
+	${Boost_INCLUDE_DIRS}
+)
 
-install(TARGETS PDController DESTINATION /usr/local/lib/choreonoid-1.5/rtc)
-install(FILES pdgain.txt ../JAXON_RTC.conf DESTINATION /usr/local/lib/choreonoid-1.5/rtc)
+link_directories(
+	${openrtm_aist_LIBRARY_DIRS}
+	${cnoid_plugin_LIBRARY_DIRS}
+	${Boost_LIBRARY_DIRS}
+)
+
+add_library(PDController SHARED PDController.cpp)
+set_target_properties(PDController PROPERTIES PREFIX "")
+
+set(target PDController)
+target_link_libraries(PDController
+	${openrtm_aist_LIBRARIES}
+	${cnoid_plugin_LIBRARIES}
+	${Boost_LIBRARIES}
+)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+
+install(TARGETS PDController LIBRARY DESTINATION /usr/lib/choreonoid-1.5/rtc)
+install(FILES pdgain.txt ../JAXON_RTC.conf DESTINATION /usr/lib/choreonoid-1.5/rtc)


### PR DESCRIPTION
PDControllerコンポーネントをコンパイルしchoreonoidからBodyRTCとして読み込んだ際，正常に読み込みが出来ない(初期化に失敗)問題があったため，CMakeLists.txtを書き直しきちんとライブラリファイルを生成するように修正．

きちんとBodyRTCとして読み込めることを確認．