### PR TITLE
予見制御のテストプログラムの追加

### DIFF
--- a/src/patten/PreviewController/CMakeLists.txt
+++ b/src/patten/PreviewController/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(testPreviewControl)
+
+set(DCMAKE_BUILD_TYPE Debug)
+find_package(Eigen3 REQUIRED)
+find_package(PythonLibs REQUIRED)
+add_definitions(-lstdc++ -std=c++11)
+
+include_directories(
+	${EIGEN3_INCLUDE_DIR}
+	${PYTHON_INCLUDE_DIRS}
+)
+
+add_executable(testPreviewControl testPreviewControl.cpp PreviewControl.cpp PreviewControl.h)
+
+target_link_libraries(testPreviewControl ${PYTHON_LIBRARIES})

--- a/src/patten/PreviewController/PreviewControl.cpp
+++ b/src/patten/PreviewController/PreviewControl.cpp
@@ -1,0 +1,65 @@
+#include "PreviewControl.h"
+
+using namespace MotionControl;
+
+/* 目標ZMPの補間 */
+void ZMPPreviewControl::RefZmpTrajectory(vector<Vector4f> foot_step_list)
+{
+	size_t foot_step_count = 1;
+	size_t size = foot_step_list.size();
+	gait_count = (foot_step_list[size-2](0)+stop_time)/dt;
+
+	for(int t=0;t<(foot_step_list[size-1](0)/dt);t++)
+	{
+		float temp_time = t*dt;
+		if(foot_step_list[foot_step_count](0) < temp_time) foot_step_count++;
+		this->refzmp.push_back(Vector2f(foot_step_list[foot_step_count-1](1), foot_step_list[foot_step_count-1](2)));
+	}
+}
+
+/* 制御入力の計算 */
+void ZMPPreviewControl::calc_u()
+{
+	Matrix<float,1,2> du;
+	Matrix<float,4,4> xi(xi0.transpose());
+
+	du = K*xk_ex;
+	for(int preview_step=1;preview_step<=(preview_delay/dt);preview_step++)
+	{
+		fi = -(1.0/(R+G.transpose()*P*G))*G.transpose()*xi.pow(preview_step-1)*P*GR;
+		du += fi * (refzmp[preview_step+loop_step] - refzmp[preview_step+loop_step-1]);
+	}
+	u+=du;
+}
+
+/* 重心軌道の計算 */
+bool ZMPPreviewControl::calc_xk(Vector2f &cog)
+{
+	if(gait_count <= loop_step)
+	{
+		loop_step = 0;
+		return false;
+	}
+
+	//Output
+	p = c * xk;
+	this->temp_refzmp = refzmp[loop_step];
+
+	//Error ZMP
+	e = temp_refzmp.transpose() - p;
+
+	//Extend xk
+	xk_ex << e, xk-xkp;
+	xkp = xk;
+
+	//Calculation Input
+	calc_u();
+
+	//Calculation xk
+	xk = A*xk + b*u;
+	cog << xk(0,0), xk(0,1);
+
+	//Increment
+	loop_step++;
+	return true;
+}

--- a/src/patten/PreviewController/PreviewControl.h
+++ b/src/patten/PreviewController/PreviewControl.h
@@ -1,0 +1,120 @@
+#include <iostream>
+#include <vector>
+#include <Eigen/Dense>
+#include <unsupported/Eigen/MatrixFunctions>
+#include <boost/math/constants/constants.hpp>
+
+using namespace std;
+using namespace Eigen;
+
+namespace MotionControl
+{
+	/* 定数となる物理パラメータ */
+	static const float ACCELERATION_OF_GRAVITY = -9.810;
+	static const float HEIGHT_ZC = 0.270;
+	static const float PI = boost::math::constants::pi<double>();
+	static int loop_step = 0;
+
+	/* ZMP予見制御を計算するクラス */
+	class ZMPPreviewControl
+	{
+		protected:
+			Matrix<float,3,3> A;	//
+			Matrix<float,3,1> b;	//
+			Matrix<float,1,3> c;	//
+
+			Matrix<float,3,2> xk;	//計算される重心(位置，速度，加速度)
+			Matrix<float,3,2> xkp;	//t-1における重心
+			Matrix<float,1,2> u;	//制御入力
+			Matrix<float,1,2> p;	//出力ZMP
+			Matrix<float,1,2> e;	//ZMP誤差
+			float fi;				//フィードバックゲイン
+
+			int gait_count;
+			int stop_time;
+
+			const float preview_delay;	//予見制御幅
+			const float dt;				//サンプリングタイム
+			
+			const double Q,R;
+
+		private:
+			/* 拡大系のシステム */
+			Matrix<float,4,4> phi;
+			Matrix<float,4,1> G;
+			Matrix<float,4,1> GR;
+			Matrix<float,4,4> xi0;
+			Matrix<float,4,2> xk_ex;
+			Matrix<float,4,4> P;
+			Matrix<float,1,4> K;
+
+			Matrix<float,2,1> temp_refzmp;
+
+		public:
+			vector<Vector2f> refzmp;
+		public:
+			/* 定数となるパラメータの初期化 */
+			ZMPPreviewControl(const float _dt, const float _preview_delay, const double _Q=1e+08, const double _R=1.0)
+				: dt(_dt),
+				  preview_delay(_preview_delay),
+					stop_time(1.0),
+				  xk(Matrix<float,3,2>::Zero()),
+				  xkp(Matrix<float,3,2>::Zero()),
+					xk_ex(Matrix<float,4,2>::Zero()),
+				  u(Matrix<float,1,2>::Zero()),
+				  p(Matrix<float,1,2>::Zero()),
+				  Q(_Q),
+				  R(_R)
+			{
+				A << 1, dt, 0.5*dt*dt,
+					 0, 1, dt,
+					 0, 0, 1;
+				b << dt*dt*dt/6.0, 0.5*dt*dt, dt;
+				c << 1, 0, HEIGHT_ZC / ACCELERATION_OF_GRAVITY;
+			}
+
+			/**/
+			void ExtendPreviewControlParam()
+			{
+				Matrix<float,1,3> cA(c*A);
+				Matrix<float,1,1> cb(c*b);
+				Matrix<float,4,4> I(Matrix<float,4,4>::Identity());
+
+				phi << 1, -cA(0), -cA(1), -cA(2),
+					   0, A(0,0), A(0,1), A(0,2),
+					   0, A(1,0), A(1,1), A(1,2),
+					   0, A(2,0), A(2,1), A(2,2);
+				G << -cb, b(0), b(1), b(2);
+				GR <<1, 0, 0, 0;
+				P << 3.4360e+09, -5.7313e+10, -9.7980e+09, -4.8302e+07,
+						-5.7313e+10, 9.8950e+11, 1.6919e+11, 8.3865e+08,
+						-9.7980e+09, 1.6919e+11, 2.8929e+10, 1.4345e+08,
+						-4.8302e+07, 8.3865e+08, 1.4345e+08, 7.2054e+05;
+				K << 2.6772e+03, -9.1990e+04, -1.6264e+04, -172.6188;
+
+				xi0 = (I-G*(1.0/(R+G.transpose()*P*G))*G.transpose()*P)*phi;
+			}
+
+			/* 目標ZMPの補間 */
+			void RefZmpTrajectory(vector<Vector4f> foot_step_list);
+
+			/* 目標ZMPの取得 */
+			void get_ref_zmp(Matrix<float,2,1> &refzmp)
+			{
+				refzmp = this->temp_refzmp;
+			}
+			
+			/* 出力ZMPの取得 */
+			void get_current_zmp(Matrix<float,1,2> &current_zmp)
+			{
+				current_zmp = p;
+			}
+
+			/* 制御入力の計算 */
+			void calc_u();
+
+			/* 重心軌道の計算 */
+			bool calc_xk(Vector2f &cog);
+	};
+}
+

--- a/src/patten/PreviewController/testPreviewControl.cpp
+++ b/src/patten/PreviewController/testPreviewControl.cpp
@@ -1,0 +1,56 @@
+#include "PreviewControl.h"
+#include "matplotlibcpp.h"
+
+using namespace MotionControl;
+namespace plt = matplotlibcpp;
+
+int main(int argc, char *argv[])
+{
+	bool result=true;
+	Vector2f cog;
+	vector<Vector4f> foot_step_list;
+	vector<float> cog_list_x, cog_list_y;
+	vector<float> refzmp_x, refzmp_y;
+
+	/* 予見制御クラス */
+	ZMPPreviewControl preview_control(0.01, 1.0);
+	
+	/* 予見制御システムを拡大系で扱う */
+	preview_control.ExtendPreviewControlParam();
+
+	/* 目標ZMPを与える */
+	foot_step_list.push_back(Vector4f(0.0,0.0,0.0,0.0));
+	foot_step_list.push_back(Vector4f(0.3,0.0,0.05,0.0));
+	foot_step_list.push_back(Vector4f(0.6,0.01,-0.05,0.0));
+	foot_step_list.push_back(Vector4f(0.9,0.02,0.05,0.0));
+	foot_step_list.push_back(Vector4f(1.2,0.02,0.0,0.0));
+	foot_step_list.push_back(Vector4f(3.2,0.02,0.0,0.0));
+	
+	/* 目標ZMP軌道の補間 */
+	preview_control.RefZmpTrajectory(foot_step_list);
+	
+	/* 予見制御計算ループ */	
+	while(result){
+		result = preview_control.calc_xk(cog);
+		cog_list_x.push_back(cog(0));
+		cog_list_y.push_back(cog(1));
+	}
+	
+	/* グラフ描画用 */	
+	for(size_t i=0;i<preview_control.refzmp.size();i++)
+	{
+		refzmp_x.push_back(preview_control.refzmp[i](0));
+		refzmp_y.push_back(preview_control.refzmp[i](1));
+	}	
+
+	/* 歩行パターン軌道描画 */
+	plt::title("Reference ZMP Trajectory");
+	plt::xlabel("x[m]");
+	plt::ylabel("y[m]");
+	plt::xlim(-0.01, 0.03);
+	plt::ylim(0.06, -0.06);
+	plt::named_plot("Reference ZMP", refzmp_x, refzmp_y, "-r");
+	plt::named_plot("Center of Mass", cog_list_x, cog_list_y, "-g");
+	plt::legend();
+	plt::show();
+}


### PR DESCRIPTION
予見制御を使用した歩行パターン生成のテストプログラムです。

matplotlib-cppを使用して目標ZMPと重心軌道の描画を行っていますのでgithubからcloneして必要なファイルをコピーした上でコンパイルして下さい。

ちなみに実行した場合の図です。

![figure_1](https://cloud.githubusercontent.com/assets/6177252/17052607/40fcd9ea-5039-11e6-97e7-3e6f24b69fca.png)
